### PR TITLE
record catalog as part of repo insertion

### DIFF
--- a/api/getMetric/getMetric.go
+++ b/api/getMetric/getMetric.go
@@ -119,7 +119,7 @@ func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	}
 
 	collection := mongoClient.Database(os.Getenv("MONGO_DB")).Collection(catalog)
-	repo, found, err := util.GetRepoFromDB(ctx, collection, owner, name)
+	repo, found, err := util.GetRepoFromDB(ctx, collection, catalog, owner, name)
 	if err != nil {
 		message, _ := json.Marshal(singleMetricRepsone{Message: "Error getting repos from mongoDB"})
 		return events.APIGatewayProxyResponse{

--- a/api/queryRepository/handler/queryRepoHandler.go
+++ b/api/queryRepository/handler/queryRepoHandler.go
@@ -132,7 +132,13 @@ func handler(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	}
 
 	collection := mongoClient.Database(os.Getenv("MONGO_DB")).Collection(catalog)
-	err = util.SetScoreState(ctx, collection, owner, name, 1)
+	
+	err = util.SyncRepoWithDB(ctx, collection, util.RepoInfo{
+		Catalog: catalog,
+		Owner: owner,
+		Name: name,
+		Status: 1,
+	})
 
 	if err != nil {
 		return events.APIGatewayProxyResponse{

--- a/api/util/queries.go
+++ b/api/util/queries.go
@@ -87,7 +87,7 @@ func GetGithubDependencies(client *http.Client, repo *RepoInfo) error {
 
 	// hasNextGraphPage := true
 	hasNextDependencyPage := true
-	var dependencies []Dependency
+	// var dependencies []Dependency
 	var data DependencyResponse
 
 	// temp: not iterating over all manifests, only primary one
@@ -143,8 +143,8 @@ func GetGithubDependencies(client *http.Client, repo *RepoInfo) error {
 				Version: node.Node.Requirements,
 			}
 			// not pulling enough info out, this shouldn't be needed
-			if !dependencyInSlice(newDep, dependencies) && newDep.Name != "" && newDep.Owner != "" {
-				dependencies = append(dependencies, newDep)
+			if !dependencyInSlice(newDep, repo.Dependencies) && newDep.Name != "" && newDep.Owner != "" {
+				repo.Dependencies = append(repo.Dependencies, newDep)
 			}
 		}
 		hasNextDependencyPage = data.Data.Repository.DependencyGraphManifests.Edges[0].Node.Dependencies.PageInfo.HasNextPage
@@ -154,7 +154,7 @@ func GetGithubDependencies(client *http.Client, repo *RepoInfo) error {
 	// graphCursor = data.Data.Repository.DependencyGraphManifests.PageInfo.EndCursor
 	// }
 
-	repo.Dependencies = append(repo.Dependencies, dependencies...)
+	// repo.Dependencies = append(repo.Dependencies, dependencies...)
 
 	return nil
 }


### PR DESCRIPTION
During some refactoring the catalog stopped being recorded. Although it was not directly needed it caused problems down the line for dependency querying as it is used to get the correct collection