### PR TITLE
Added error messages when API is unable to fetch metrics on website

### DIFF
--- a/website/oss-score-site/src/components/Homepage.js
+++ b/website/oss-score-site/src/components/Homepage.js
@@ -178,8 +178,10 @@ export default function Home(props) {
                     scoreDisplay += DisplayScores(owner, repo, metrics)
                 }
             } else if (response.status === 406) {
+                alert("At least one of the repositories entered is private or does not exist")
                 console.error("Repository entered does not exist")
             } else {
+                alert("Error connecting to OSS-Score API")
                 console.error("Error connecting to OSS-Score API")
             }
         } catch (error) {


### PR DESCRIPTION
Added alert for API 406 error and other API errors to inform user that metrics could not be fetched