### PR TITLE
Fixed license names on two lines bug

### DIFF
--- a/website/oss-score-site/src/components/DisplayScores.js
+++ b/website/oss-score-site/src/components/DisplayScores.js
@@ -123,7 +123,14 @@ const getMetricDisplay = (metricScore, metricName, barDisplay, outOfTen, lg) => 
             if (metricScore.license === '') {
                 result += '<div class="metric-num"> N/A'
             } else {
-                result += '<div class="metric-num">' + metricScore.license
+                // make sure license name fits in the box
+                if (metricScore.license.length > 12) {
+                    result += '<div class="metric-num" style="font-size: 15px">' + metricScore.license
+                } else if (metricScore.license.length > 10) {
+                    result += '<div class="metric-num" style="font-size: 21px">' + metricScore.license
+                }else {
+                    result += '<div class="metric-num">' + metricScore.license
+                }
                 result += '<div class="metric-confidence">Score: ' + metricScore.metric + '/10</div>'
             }
         } else if (metricName === 'Last Commit') {

--- a/website/oss-score-site/src/components/Homepage.css
+++ b/website/oss-score-site/src/components/Homepage.css
@@ -474,10 +474,15 @@ label {
 
 .sm-container .metric-confidence {
     font-size: 13px;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
 }
 
 .sm-container .metric-num {
     font-size: 25px;
+    height: 50px;
 }
 
 


### PR DESCRIPTION
Added logic in display scores to make license text smaller when dealing with long license names